### PR TITLE
One china policy

### DIFF
--- a/vendor/assets/stylesheets/flags/_flag-list.scss
+++ b/vendor/assets/stylesheets/flags/_flag-list.scss
@@ -274,7 +274,7 @@
 @include flag(tun, tn, 788, tun, tun);
 @include flag(tur, tr, 792, tur, tur);
 @include flag(tuv, tv, 798, tuv, tuv);
-@include flag(twn, tw, 158, null, null);
+@include flag(chn, tw, 158, null, null);
 @include flag(tza, tz, 834, tan, tan);
 @include flag(uga, ug, 800, uga, uga);
 @include flag(ukr, ua, 804, ukr, ukr);

--- a/vendor/assets/stylesheets/flags/_flag-list.scss
+++ b/vendor/assets/stylesheets/flags/_flag-list.scss
@@ -274,7 +274,7 @@
 @include flag(tun, tn, 788, tun, tun);
 @include flag(tur, tr, 792, tur, tur);
 @include flag(tuv, tv, 798, tuv, tuv);
-@include flag(chn, tw, 158, null, null);
+@include flag(twn, tw, 158, null, null);
 @include flag(tza, tz, 834, tan, tan);
 @include flag(uga, ug, 800, uga, uga);
 @include flag(ukr, ua, 804, ukr, ukr);
@@ -336,4 +336,10 @@
 .flag-fifa-wal {
   background-image: asset-url("#{$flag-css-png-path}/wal.png");
   background-image: asset-url("#{$flag-css-path}/wal.svg");
+}
+
+// irish foreign policy follows the one-china-policy
+.flag-twn, .flag-tw, .flag-158 {
+  background-image: asset-url("#{$flag-css-png-path}/chn.png");
+  background-image: asset-url("#{$flag-css-path}/chn.svg");
 }


### PR DESCRIPTION
An internet user with too much time our their hands noticed that our flag for Taiwan in the telephone country code dropdown is that of the Republic of China. 

![2F00D511@7C9F7D5C B942235E](https://user-images.githubusercontent.com/5627696/72806230-a2849380-3c4c-11ea-99b5-4bba1d8582cc.jpg)

This is indifference to the one-china-policy which does not recognise the state of Republic of China, only the Peoples Republic of China (PROC).

As it is current Irish policy to adhere to the one-china-policy, this PR adds a rule to override the css to use the PROC flag instead.